### PR TITLE
Add maven upload gradle task

### DIFF
--- a/dtglib/build.gradle
+++ b/dtglib/build.gradle
@@ -14,7 +14,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.14"
     }
 }
 

--- a/dtglib/build.gradle
+++ b/dtglib/build.gradle
@@ -1,8 +1,22 @@
 apply plugin: 'com.android.library'
 apply from: '../version.gradle'
 apply from: 'bintray.gradle'
+apply from: file('../gradle/gradle-mvn-push.gradle')
 
 group='com.github.kaltura'
+
+buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url "http://mobile-maven-dev.crunchydev.com:8081/nexus/content/groups/public"
+        }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.14"
+    }
+}
 
 android {
     compileSdkVersion 25

--- a/dtglib/gradle.properties
+++ b/dtglib/gradle.properties
@@ -1,0 +1,11 @@
+GROUP=com.kaltura.dtg
+VERSION_NAME=2.2.5-ellation
+
+RELEASE_REPOSITORY_URL=http://mobile-maven-dev.crunchydev.com:8081/nexus/content/repositories/releases/
+SNAPSHOT_REPOSITORY_URL=http://mobile-maven-dev.crunchydev.com:8081/nexus/content/repositories/snapshots/
+
+POM_ARTIFACT_ID=dtglib
+POM_NAME=dtglib
+POM_PACKAGING=aar
+
+POM_DESCRIPTION=Ellation DTG: Kaltura Download-To-Go

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -29,7 +29,7 @@ uploadArchives {
     }
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchivmvnes") }
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
         sign configurations.archives
     }
 

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
-apply plugin: 'org.jetbrains.dokka-android'
 
 version = VERSION_NAME
 group = GROUP
@@ -39,14 +38,9 @@ uploadArchives {
         from android.sourceSets.main.java.srcDirs
     }
 
-    task javadocJar(type: Jar, dependsOn: 'dokka') {
+    task javadocJar(type: Jar) {
         classifier 'javadoc'
         from "$buildDir/javadoc"
-    }
-
-    dokka {
-        outputFormat 'javadoc'
-        outputDirectory "$buildDir/javadoc"
     }
 
     artifacts {

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'maven'
+apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka-android'
+
+version = VERSION_NAME
+group = GROUP
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            pom.groupId = GROUP
+            pom.artifactId = POM_ARTIFACT_ID
+            pom.version = VERSION_NAME
+
+            repository(url: RELEASE_REPOSITORY_URL)
+            snapshotRepository(url: SNAPSHOT_REPOSITORY_URL)
+
+            pom.project {
+                name POM_NAME
+                packaging POM_PACKAGING
+                description POM_DESCRIPTION
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchivmvnes") }
+        sign configurations.archives
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+    }
+
+    task javadocJar(type: Jar, dependsOn: 'dokka') {
+        classifier 'javadoc'
+        from "$buildDir/javadoc"
+    }
+
+    dokka {
+        outputFormat 'javadoc'
+        outputDirectory "$buildDir/javadoc"
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives javadocJar
+    }
+}


### PR DESCRIPTION
Jira: [CXAND-2676](https://ellation.atlassian.net/browse/CXAND-2676)

### What has been done
1. Added `uploadArchives` gradle task that uploads the kaltura dtg library build to our maven
2. Specified an ellation postfix for the version name to distinguish our build from the official Kaltura one. It will look like this `com.kaltura.dtg:dtglib:2.2.5-ellation`

<img width="1204" alt="screen shot 2017-10-16 at 4 04 52 pm" src="https://user-images.githubusercontent.com/1655758/31613461-de6bb77c-b28b-11e7-836a-bcf7f6d69fd4.png">

### How to test
1. Run the `uploadArchives` gradle task
2. Make sure the build and uploading succeeded on http://mobile-maven-dev.crunchydev.com:8081/nexus/#view-repositories;releases~browsestorage